### PR TITLE
Added PREMIS agent and event

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,16 @@ Windows - There are multiple ways to use BASH within windows. Linux operating sy
 https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/
 
 #### Download and Extract Saxon Home Edition
-https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/
+https://github.com/Saxonica/Saxon-HE/releases
 
-#### Update config.txt
-DROID and Saxon are standalone executable programs that do no require installation. You should move them to a permanent location on the filesystem. You'll then need to update the 'config.txt'. This contains variables, which let the bash script know where DROID and Saxon are located. Replace the filepaths in the file, with the absolute paths to the droid-command-line.jar file and the saxon-he.jar file. Further instructions are provided in the config.txt file.
-
+#### Location of DROID and Saxon
+DROID and Saxon are standalone executable programs that do not require installation. You should move them to a permanent location on the filesystem.
 
 ### Download the Repository
 `git clone https://github.com/bishbashbackup/premissh.git`
 
+### Update config.txt
+You'll then need to update the 'config.txt'. This contains variables, which let the bash script know where DROID and Saxon are located. Replace the filepaths in the file, with the absolute paths to the droid-command-line.jar file and the saxon-he.jar file. Further instructions are provided in the config.txt file.
 
 ### Make Executable
 

--- a/premissh.sh
+++ b/premissh.sh
@@ -11,12 +11,19 @@ tempdir="$(mktemp -d "${bag}"/temp-XXXXX)"
 droidcsv="$(mktemp -p "${tempdir}" droid_XXXXX.csv)"
 droidxml="$(mktemp -p "${tempdir}" droid_XXXXX.xml)"
 premisxml="$(mktemp -p "${tempdir}" premis_XXXXX.xml)"
+executiondate="$(date -Ins)"
+eventidentifier="$(uuidgen)"
+droidversion="$(java -jar "$DROID" -v)"
+droidsignaturefiles="$(java -jar "$DROID" -x)"
 
 java -jar "$DROID" "$data" -R -o "$droidcsv" -Pf "$droidproperties"
 
 echo '<?xml version="1.0" encoding="UTF-8"?>' >> "$droidxml"
 echo "<DATA>" >> "$droidxml"
 
+echo -e "<EVENT>\n\t<DATE>$executiondate</DATE>\n\t<ID>$eventidentifier</ID>\n</EVENT>" >> "$droidxml"
+echo -e "<DROIDINFO>\n\t<VERSION>$droidversion</VERSION>" >> "$droidxml"
+echo -e "\t<SIGNATURES>$droidsignaturefiles</SIGNATURES>\n</DROIDINFO>" >> "$droidxml"
 IFS=',' read -r -a fields < "$droidcsv"
 
 tail -n +2 "$droidcsv" | while IFS=',' read -r line; do

--- a/resources/base_premis.xsl
+++ b/resources/base_premis.xsl
@@ -11,9 +11,40 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		xsi:schemaLocation="http://www.loc.gov/premis/v3 https://www.loc.gov/standards/premis/premis.xsd" 
 		version="3.0">
+		<xsl:apply-templates select="DATA/EVENT" />
+		<xsl:apply-templates select="DATA/DROIDINFO" />
 		<xsl:apply-templates select="DATA/OBJECT" />
 	</premis:premis>
 </xsl:template>
+
+<xsl:template match="EVENT">
+	<premis:event>
+		<premis:eventIdentifier>
+			<premis:eventIdentifierType>UUID</premis:eventIdentifierType>
+        	<premis:eventIdentifierValue><xsl:apply-templates select="ID"/></premis:eventIdentifierValue>
+    	</premis:eventIdentifier>
+		<premis:eventType authority="eventType" authorityURI="https://id.loc.gov/vocabulary/preservation/eventType" valueURI="http://id.loc.gov/vocabulary/preservation/eventRelatedAgentRole/for">format identification</premis:eventType>
+		<premis:eventDateTime><xsl:apply-templates select="DATE"/></premis:eventDateTime>
+		<premis:linkingAgentIdentifier>
+        	<premis:linkingAgentIdentifierType>local</premis:linkingAgentIdentifierType>
+        	<premis:linkingAgentIdentifierValue>DROID</premis:linkingAgentIdentifierValue>
+        	<premis:linkingAgentRole authority="eventRelatedAgentRole" authorityURI="http://id.loc.gov/vocabulary/preservation/eventRelatedAgentRole" valueURI="http://id.loc.gov/vocabulary/preservation/eventRelatedAgentRole/exe">executing program</premis:linkingAgentRole>
+    	</premis:linkingAgentIdentifier>
+    </premis:event>
+</xsl:template>
+
+<xsl:template match="DROIDINFO">
+	<premis:agent>
+  		<premis:agentIdentifier>
+    		<premis:agentIdentifierType>local</premis:agentIdentifierType>
+      		<premis:agentIdentifierValue>DROID</premis:agentIdentifierValue>
+    	</premis:agentIdentifier>
+		<premis:agentName>DROID</premis:agentName>
+    	<premis:agentType authority="agentType" authorityURI="http://id.loc.gov/vocabulary/preservation/agentType" valueURI="http://id.loc.gov/vocabulary/preservation/agentType/sof">software</premis:agentType>
+		<premis:agentVersion><xsl:apply-templates select="VERSION"/></premis:agentVersion>
+		<premis:agentNote><xsl:apply-templates select="SIGNATURES"/></premis:agentNote>
+	</premis:agent>
+ </xsl:template>
 
 <xsl:template match="OBJECT">
 	<premis:object xsi:type="premis:file">
@@ -21,7 +52,6 @@
 			<premis:objectIdentifierType>local</premis:objectIdentifierType>
 			<premis:objectIdentifierValue><xsl:apply-templates select="BASE/NAME" /></premis:objectIdentifierValue>
 		</premis:objectIdentifier>
-		<premis:objectCategory>file</premis:objectCategory>
 		<premis:objectCharacteristics>
 			<premis:compositionLevel>0</premis:compositionLevel>
 			<premis:fixity>
@@ -38,8 +68,6 @@
 				<premis:formatRegistry>
 					<premis:formatRegistryName>PRONOM</premis:formatRegistryName>
 					<premis:formatRegistryKey><xsl:apply-templates select="DROID/PUID" /></premis:formatRegistryKey>
-					<premis:formatRegistryRole>specification</premis:formatRegistryRole>
-					<premis:formatNote>identification</premis:formatNote>
 				</premis:formatRegistry>
 			</premis:format>
 			<xsl:if test="string(BASE/SOFTWARE) or string(BASE/CREATION_DATE)">

--- a/resources/base_premis.xsl
+++ b/resources/base_premis.xsl
@@ -11,9 +11,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 		xsi:schemaLocation="http://www.loc.gov/premis/v3 https://www.loc.gov/standards/premis/premis.xsd" 
 		version="3.0">
+		<xsl:apply-templates select="DATA/OBJECT" />
 		<xsl:apply-templates select="DATA/EVENT" />
 		<xsl:apply-templates select="DATA/DROIDINFO" />
-		<xsl:apply-templates select="DATA/OBJECT" />
 	</premis:premis>
 </xsl:template>
 


### PR DESCRIPTION
Hi @bishbashbackup, I took a look at your project and I really love it!

This is one of my first "real" pull request, and my knowledge of Bash is pretty fresh, so there might be problems.

The pull request includes a few things:
* Minor changes to README.MD to be clearer and to provide the right URL to Saxon;
* Adding a PREMIS Event for the format identification process - that helps keeping track of the time the analysis was made (I added a dependency to uuidgen but I suppose it's OK as it is available in many distributions);
* Adding a PREMIS Agent for DROID to record the tool version and signature files - again, as the identification process may produce different results with a further version, it's important to record this;
* Eliminating some problematic / useless PREMIS elements (formatCategory is not a valid XML element - instead, the semantic unit is expressed in the premis:object/@xsi:type attribute; formatRegistryRole is useful only if you have several identifiers in different registries; formatNote is not allowed here, only as a following sibling of formatDesignation / formatRegistry).

I still have issues with the exiftool call. I think the terminal can not use aliases, so I guess it should be handled like you did for other dependencies (DROID and Saxon). But again, I'm a beginner so I might be wrong.

Thank you, finally, for giving me the opportunity to practice some new skills I have acquired recently!!